### PR TITLE
fix/lifecycle-viewmodel_dependency_error

### DIFF
--- a/AppLovin MAX Demo App - Java/app/build.gradle
+++ b/AppLovin MAX Demo App - Java/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'

--- a/AppLovin MAX Demo App - Java/app/build.gradle
+++ b/AppLovin MAX Demo App - Java/app/build.gradle
@@ -25,7 +25,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'

--- a/AppLovin MAX Demo App - Kotlin/app/build.gradle
+++ b/AppLovin MAX Demo App - Kotlin/app/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion"
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.material:material:1.1.0'
     implementation 'androidx.core:core-ktx:1.3.0'
 


### PR DESCRIPTION
We need to update the `appCompat` dependency version we're using since it currently pulls down a mismatched version of `lifecycle-viewmodel` (2.0.0 which needs to be 2.1.0). This only caused cosmetic errors since AS will resolve it to ultimately use the later version of `lifecycle-viewmodel`.