### PR TITLE
Update LineMediationAdapter.java, Specify the appropriate width when creating an AdView.

### DIFF
--- a/Line/src/main/java/com/applovin/mediation/adapters/LineMediationAdapter.java
+++ b/Line/src/main/java/com/applovin/mediation/adapters/LineMediationAdapter.java
@@ -202,7 +202,7 @@ public class LineMediationAdapter
         }
         else
         {
-            adView = new FiveAdCustomLayout( activity, slotId, new DisplayMetrics().widthPixels );
+            adView = new FiveAdCustomLayout(activity, slotId, AppLovinSdkUtils.dpToPx(activity, adFormat.getSize().getWidth()));
             adView.setListener( new AdViewListener( listener, adFormat ) );
 
             // We always want to mute banners and MRECs


### PR DESCRIPTION
Hi there.
When I create the AdView, I pass new DisplayMetrics().widthPixels as an argument, but this is set to 0.

I fixed it to pass the appropriate value from Applovin's ad size.

Please consider this.
Thank you.