### PR TITLE
Migrated verizon adapter to yahoo mobile sdk.

### DIFF
--- a/VerizonAds/build.gradle.kts
+++ b/VerizonAds/build.gradle.kts
@@ -20,11 +20,11 @@ android.defaultConfig.versionCode = libraryVersionCode
 android.defaultConfig.versionName = libraryVersionName
 
 dependencies {
-    implementation("com.yahoo.mobile.ads:android-yahoo-mobile-sdk:1.0.0-SNAPSHOT")
+    implementation("com.yahoo.mobile.ads:android-yahoo-mobile-sdk:1.0.0")
 }
 
 repositories {
-    maven { url 'https://artifactory.yahooinc.com/artifactory/maven-beta-local/' }
+    maven { url 'https://artifactory.yahooinc.com/artifactory/maven/' }
 }
 
 publishing {
@@ -56,7 +56,7 @@ publishing {
                             .appendNode("dependency").apply {
                                 appendNode("groupId", "com.yahoo.mobile.ads")
                                 appendNode("artifactId", "android-yahoo-mobile-sdk")
-                                appendNode("version", "1.0.0-SNAPSHOT")
+                                appendNode("version", "1.0.0")
                                 appendNode("scope", "compile")
                             }
                 }

--- a/VerizonAds/build.gradle.kts
+++ b/VerizonAds/build.gradle.kts
@@ -20,11 +20,11 @@ android.defaultConfig.versionCode = libraryVersionCode
 android.defaultConfig.versionName = libraryVersionName
 
 dependencies {
-    implementation("com.verizon.ads:android-vas-standard-edition:${libraryVersions["verizonAds"]}")
+    implementation("com.yahoo.mobile.ads:android-yahoo-mobile-sdk:1.0.0-SNAPSHOT")
 }
 
 repositories {
-    maven { url = uri("https://artifactory.verizonmedia.com/artifactory/maven/") }
+    maven { url 'https://artifactory.yahooinc.com/artifactory/maven-beta-local/' }
 }
 
 publishing {
@@ -54,9 +54,9 @@ publishing {
                     // Add Verizon Ads SDK to list of dependencies.
                     appendNode("dependencies")
                             .appendNode("dependency").apply {
-                                appendNode("groupId", "com.verizon.ads")
-                                appendNode("artifactId", "android-vas-standard-edition")
-                                appendNode("version", libraryVersions["verizonAds"])
+                                appendNode("groupId", "com.yahoo.mobile.ads")
+                                appendNode("artifactId", "android-yahoo-mobile-sdk")
+                                appendNode("version", "1.0.0-SNAPSHOT")
                                 appendNode("scope", "compile")
                             }
                 }


### PR DESCRIPTION
In order for this adapter to work with AppLovin you will need to create a class com.verizon.ads.VASAds.java in the sample app project so that the AppLovin SDK thinks the Verizon SDK is present. The Yahoo Mobile SDK is what is driving the adapter but the old class is how AppLovin verifies Verizon Ads is library is present so we have to fake it to get the adapter configured successfully. 