### PR TITLE
Update impression tracking method on Verve banner ads

### DIFF
--- a/Verve/build.gradle.kts
+++ b/Verve/build.gradle.kts
@@ -4,9 +4,9 @@ plugins {
 }
 
 private val versionMajor = 2
-private val versionMinor = 12
-private val versionPatch = 1
-private val versionAdapterPatch = 1
+private val versionMinor = 13
+private val versionPatch = 0
+private val versionAdapterPatch = 0
 
 val libraryVersionName by extra("${versionMajor}.${versionMinor}.${versionPatch}.${versionAdapterPatch}")
 val libraryVersionCode by extra((versionMajor * 1000000) + (versionMinor * 10000) + (versionPatch * 100) + versionAdapterPatch)

--- a/Verve/src/main/java/com/applovin/mediation/adapters/VerveMediationAdapter.java
+++ b/Verve/src/main/java/com/applovin/mediation/adapters/VerveMediationAdapter.java
@@ -221,6 +221,7 @@ public class VerveMediationAdapter
         updateUserConsent( parameters );
 
         adViewAd = new HyBidAdView( activity, getSize( adFormat ) );
+        adViewAd.setTrackingMethod(ImpressionTrackingMethod.AD_VIEWABLE);
         adViewAd.renderAd( parameters.getBidResponse(), new AdViewListener( listener ) );
     }
 


### PR DESCRIPTION
This PR contains the following changes:

- Update Verve adapter version to 2.13.0.0
- Update the impression tracking method on Verve banners