### PR TITLE
[Chartboost] Release SDK 9.0.0

### DIFF
--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.0.0.0
+* Certified with Chartboost SDK 9.0.0.
+
 ## 8.4.3.1
 * Fix incomplete ad display failure error message.
 

--- a/Chartboost/build.gradle.kts
+++ b/Chartboost/build.gradle.kts
@@ -3,10 +3,10 @@ plugins {
     id("maven-publish")
 }
 
-private val versionMajor = 8
-private val versionMinor = 4
-private val versionPatch = 3
-private val versionAdapterPatch = 1
+private val versionMajor = 9
+private val versionMinor = 0
+private val versionPatch = 0
+private val versionAdapterPatch = 0
 
 val libraryVersionName by extra("${versionMajor}.${versionMinor}.${versionPatch}.${versionAdapterPatch}")
 val libraryVersionCode by extra((versionMajor * 1000000) + (versionMinor * 10000) + (versionPatch * 100) + versionAdapterPatch)

--- a/Chartboost/src/main/java/com/applovin/mediation/adapters/ChartboostMediationAdapter.java
+++ b/Chartboost/src/main/java/com/applovin/mediation/adapters/ChartboostMediationAdapter.java
@@ -468,8 +468,6 @@ public class ChartboostMediationAdapter
                     {
                         ChartboostMediationAdapterRouter.this.onAdLoaded( location );
                     }
-
-                    showAdViewDelayed();
                 }
             }
 
@@ -589,8 +587,6 @@ public class ChartboostMediationAdapter
                     {
                         ChartboostMediationAdapterRouter.this.onAdLoaded( location );
                     }
-
-                    showAdViewDelayed();
                 }
             }
 

--- a/Chartboost/src/main/java/com/applovin/mediation/adapters/ChartboostMediationAdapter.java
+++ b/Chartboost/src/main/java/com/applovin/mediation/adapters/ChartboostMediationAdapter.java
@@ -236,7 +236,7 @@ public class ChartboostMediationAdapter
         else
         {
             log( "Rewarded ad not ready" );
-            ROUTER.onAdDisplayFailed( mLocation, new MaxAdapterError( -4205, "Ad Display Failed" ) );
+            ROUTER.onAdDisplayFailed( mLocation, new MaxAdapterError( ERROR_CODE_AD_DISPLAY_FAILED, "Ad Display Failed" ) );
         }
     }
 
@@ -405,7 +405,7 @@ public class ChartboostMediationAdapter
 
             @Override
             public void onAdShown(@NonNull ShowEvent showEvent, @Nullable ShowError showError) {
-                String location = adView.getLocation();
+                String location = showEvent.getAd().getLocation();
                 if ( showError != null )
                 {
                     Exception exception = showError.getException();
@@ -413,7 +413,7 @@ public class ChartboostMediationAdapter
                     if(exception != null) {
                         exceptionMsg = exception.toString();
                     }
-                    MaxAdapterError adapterError = new MaxAdapterError( -4205, "Ad Display Failed", showError.getCode().getErrorCode(), exceptionMsg );
+                    MaxAdapterError adapterError = new MaxAdapterError( ERROR_CODE_AD_DISPLAY_FAILED, "Ad Display Failed", showError.getCode().getErrorCode(), exceptionMsg );
 
                     log( "Interstitial failed \"" + location + "\" to show with error: " + showError.getCode() );
                     ChartboostMediationAdapterRouter.this.onAdDisplayFailed( location, adapterError );
@@ -444,7 +444,7 @@ public class ChartboostMediationAdapter
 
             @Override
             public void onAdLoaded(@NonNull CacheEvent cacheEvent, @Nullable CacheError cacheError) {
-                String location = adView.getLocation();
+                String location = cacheEvent.getAd().getLocation();
                 if ( cacheError != null )
                 {
                     MaxAdapterError adapterError = toMaxError( cacheError );
@@ -475,7 +475,7 @@ public class ChartboostMediationAdapter
 
             @Override
             public void onAdClicked(@NonNull ClickEvent clickEvent, @Nullable ClickError clickError) {
-                String location = adView.getLocation();
+                String location = clickEvent.getAd().getLocation();
                 if ( clickError != null )
                 {
                     log( "Failed to record click on \"" + location + "\" because of error: " + clickError.getCode() );
@@ -525,7 +525,7 @@ public class ChartboostMediationAdapter
 
             @Override
             public void onAdShown(@NonNull ShowEvent showEvent, @Nullable ShowError showError) {
-                String location = adView.getLocation();
+                String location = showEvent.getAd().getLocation();
                 if ( showError != null )
                 {
                     Exception exception = showError.getException();
@@ -533,7 +533,7 @@ public class ChartboostMediationAdapter
                     if(exception != null) {
                         exceptionMsg = exception.toString();
                     }
-                    MaxAdapterError adapterError = new MaxAdapterError( -4205, "Ad Display Failed", showError.getCode().getErrorCode(), exceptionMsg );
+                    MaxAdapterError adapterError = new MaxAdapterError( ERROR_CODE_AD_DISPLAY_FAILED, "Ad Display Failed", showError.getCode().getErrorCode(), exceptionMsg );
 
                     log( "Rewarded failed \"" + location + "\" to show with error: " + showError.getCode() );
                     ChartboostMediationAdapterRouter.this.onAdDisplayFailed( location, adapterError );
@@ -565,7 +565,7 @@ public class ChartboostMediationAdapter
 
             @Override
             public void onAdLoaded(@NonNull CacheEvent cacheEvent, @Nullable CacheError cacheError) {
-                String location = adView.getLocation();
+                String location = cacheEvent.getAd().getLocation();
                 if ( cacheError != null )
                 {
                     MaxAdapterError adapterError = toMaxError( cacheError );
@@ -596,7 +596,7 @@ public class ChartboostMediationAdapter
 
             @Override
             public void onAdClicked(@NonNull ClickEvent clickEvent, @Nullable ClickError clickError) {
-                String location = adView.getLocation();
+                String location = clickEvent.getAd().getLocation();
                 if ( clickError != null )
                 {
                     log( "Failed to record click on \"" + location + "\" because of error: " + clickError.getCode() );
@@ -619,7 +619,7 @@ public class ChartboostMediationAdapter
 
             @Override
             public void onAdShown(@NonNull ShowEvent showEvent, @Nullable ShowError showError) {
-                String location = adView.getLocation();
+                String location = showEvent.getAd().getLocation();
                 if ( showError != null )
                 {
                     Exception exception = showError.getException();
@@ -627,7 +627,7 @@ public class ChartboostMediationAdapter
                     if(exception != null) {
                         exceptionMsg = exception.toString();
                     }
-                    MaxAdapterError adapterError = new MaxAdapterError( -4205, "Ad Display Failed", showError.getCode().getErrorCode(), exceptionMsg );
+                    MaxAdapterError adapterError = new MaxAdapterError( ERROR_CODE_AD_DISPLAY_FAILED, "Ad Display Failed", showError.getCode().getErrorCode(), exceptionMsg );
 
                     log( "AdView failed \"" + location + "\" to show with error: " + showError.getCode() );
                     ChartboostMediationAdapterRouter.this.onAdDisplayFailed( location, adapterError );
@@ -658,7 +658,7 @@ public class ChartboostMediationAdapter
 
             @Override
             public void onAdLoaded(@NonNull CacheEvent cacheEvent, @Nullable CacheError cacheError) {
-                String location = adView.getLocation();
+                String location = cacheEvent.getAd().getLocation();
                 if ( cacheError != null )
                 {
                     MaxAdapterError adapterError = toMaxError( cacheError );
@@ -689,7 +689,7 @@ public class ChartboostMediationAdapter
 
             @Override
             public void onAdClicked(@NonNull ClickEvent clickEvent, @Nullable ClickError clickError) {
-                String location = adView.getLocation();
+                String location = clickEvent.getAd().getLocation();
                 if ( clickError != null )
                 {
                     log( "Failed to record click on \"" + location + "\" because of error: " + clickError.getCode() );
@@ -751,7 +751,12 @@ public class ChartboostMediationAdapter
                 @Override
                 public void run()
                 {
-                    adView.show();
+                    if ( adView != null ) {
+                        adView.show();
+                    } else {
+                        log( "Ad load failed: Chartboost Banner AdView is not ready." );
+                        ROUTER.onAdDisplayFailed( "Unknown", new MaxAdapterError( ERROR_CODE_AD_DISPLAY_FAILED, "Ad Display Failed" ) );
+                    }
                 }
             }, 500 );
         }


### PR DESCRIPTION
The Chartboost Android SDK 9.0.0 has been updated.

Release Notes
  Improvements:
  - Implemented new public API
  - Separated ad types from main Chartboost API
  - Improved stability of the SDK

  Fixes:
  - Small quality of life improvements and fixes for pre-cache video ads
 
  Notes:
  - Sdk is compatible with Android API level 32