### PR TITLE
[Line] Call onAdHidden method when onDestroy.

### DIFF
--- a/Line/src/main/java/com/applovin/mediation/adapters/LineMediationAdapter.java
+++ b/Line/src/main/java/com/applovin/mediation/adapters/LineMediationAdapter.java
@@ -60,6 +60,9 @@ public class LineMediationAdapter
     private FiveAdCustomLayout      adView;
     private FiveAdNative            nativeAd;
 
+    private MaxInterstitialAdapterListener maxInterstitialAdapterListener;
+    private MaxRewardedAdapterListener     maxRewardedAdapterListener;
+
     public LineMediationAdapter(final AppLovinSdk sdk) { super( sdk ); }
 
     @Override
@@ -140,6 +143,18 @@ public class LineMediationAdapter
     @Override
     public void onDestroy()
     {
+        // Workaround for LINE SDK does not call onFiveAdClose method when app with Service API closed during displaying a full-screen ad.
+        if (maxInterstitialAdapterListener != null)
+        {
+            maxInterstitialAdapterListener.onInterstitialAdHidden();
+            maxInterstitialAdapterListener = null;
+        }
+        if (maxRewardedAdapterListener != null)
+        {
+            maxRewardedAdapterListener.onRewardedAdHidden();
+            maxRewardedAdapterListener = null;
+        }
+
         interstitialAd = null;
         rewardedAd = null;
         adView = null;
@@ -167,6 +182,7 @@ public class LineMediationAdapter
         log( "Showing interstitial ad for slot id: " + slotId + "..." );
 
         interstitialAd.show( activity );
+        maxInterstitialAdapterListener = listener;
     }
 
     @Override
@@ -191,6 +207,7 @@ public class LineMediationAdapter
 
         configureReward( parameters );
         rewardedAd.show( activity );
+        maxRewardedAdapterListener = listener;
     }
 
     @Override
@@ -356,6 +373,7 @@ public class LineMediationAdapter
         {
             log( "Interstitial ad hidden for slot id: " + ad.getSlotId() + "..." );
             listener.onInterstitialAdHidden();
+            maxInterstitialAdapterListener = null;
         }
 
         @Override
@@ -468,6 +486,7 @@ public class LineMediationAdapter
             }
             log( "Rewarded ad hidden for slot id: " + ad.getSlotId() + "..." );
             listener.onRewardedAdHidden();
+            maxRewardedAdapterListener = null;
         }
 
         @Override


### PR DESCRIPTION
Call onAdHidden method when onDestroy, because LINE SDK might close full-screen ad without calling onAdHidden method.

- For apps implemented using Service API (https://developer.android.com/guide/components/services), LINE SDK closes a full-screen ad without calling onFiveAdClose method, when such app is closed during displaying a full-screen ad.
- AppLovin SDK does not load the next ad for a while unless onInterstitialAdHidden / onRewardedAdHidden is called after finishing displaying a full-screen ad.

As a result,
- On app implemented by Service API
- An user closes app while displaying full-screen Ad, then restarts app. In such case, AppLoving SDK does not load the next ad for a while.

This change fixes the above issue.

We verified patched LineMediationAdapter.java fixes the issue. The reproduced app with patched LineMediationAdapter.java does not reproduce the issue.