### PR TITLE
Ensure that the context is not null when generating MobileFuse token

### DIFF
--- a/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
+++ b/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
@@ -92,8 +92,11 @@ public class MobileFuseMediationAdapter
 
         updatePrivacyPreferences( parameters );
 
+        // NOTE: `activity` can only be null in 11.1.0+, and `getApplicationContext()` is introduced in 11.1.0
+        Context context = ( activity != null ) ? activity : getApplicationContext();
+
         MobileFuseBiddingTokenRequest tokenRequest = new MobileFuseBiddingTokenRequest( MobileFuse.getPrivacyPreferences(), parameters.isTesting() );
-        MobileFuseBiddingTokenProvider.getToken( tokenRequest, activity, new TokenGeneratorListener()
+        MobileFuseBiddingTokenProvider.getToken( tokenRequest, context, new TokenGeneratorListener()
         {
             @Override
             public void onTokenGenerated(@NonNull final String signal)


### PR DESCRIPTION
This PR fixes an issue where null context causes MobileFuse bidding token generation to fail. A snippet of code has been added to ensure that the MobileFuse token provider is passed a valid (non-null) context.

This snippet is used for the same purpose in [other existing adapter implementations](https://github.com/AppLovin/AppLovin-MAX-SDK-Android/search?q=%60activity%60+can+only+be+null+in+11.1.0%2B%2C+and+%60getApplicationContext%28%29%60+is+introduced+in+11.1.0).

Fixes:
```
[MediationAdapterWrapper] Failed signal collection for MOBILEFUSE_BIDDING due to: java.lang.NullPointerException: Parameter specified as non-null is null: method com.mobilefuse.sdk.internal.MobileFuseBiddingTokenProvider$Companion.getToken, parameter context
```