### PR TITLE
[Unity - 4.7.0] Add support for MREC banner format

### DIFF
--- a/UnityAds/src/main/java/com/applovin/mediation/adapters/UnityAdsMediationAdapter.java
+++ b/UnityAds/src/main/java/com/applovin/mediation/adapters/UnityAdsMediationAdapter.java
@@ -380,6 +380,10 @@ public class UnityAdsMediationAdapter
         {
             return new UnityBannerSize( 728, 90 );
         }
+        else if ( adFormat == MaxAdFormat.MREC )
+        {
+            return new UnityBannerSize( 300, 250 );
+        }
         else
         {
             throw new IllegalArgumentException( "Unsupported ad format: " + adFormat );


### PR DESCRIPTION
Unity Ads SDK is adding support for the MREC banner format in the 4.7.0 release. This PR updates our `toUnityBannerSize` function with a new case for `MaxAdFormat.MREC`. 