### PR TITLE
Update Chartboost sdk version to 9.3.0

### DIFF
--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 9.3.0.0
+* Certified with Chartboost SDK 9.3.0.
+
 ## 9.2.1.0
 * Certified with Chartboost SDK 9.2.1.
 

--- a/Chartboost/build.gradle.kts
+++ b/Chartboost/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
 }
 
 private val versionMajor = 9
-private val versionMinor = 2
-private val versionPatch = 1
+private val versionMinor = 3
+private val versionPatch = 0
 private val versionAdapterPatch = 0
 
 val libraryVersionName by extra("${versionMajor}.${versionMinor}.${versionPatch}.${versionAdapterPatch}")
@@ -24,6 +24,10 @@ dependencies {
 
     // https://answers.chartboost.com/en-us/child_article/android
     implementation("com.google.android.gms:play-services-base:${libraryVersions["playServicesBase"]}")
+}
+
+repositories {
+    maven { url = uri("https://cboost.jfrog.io/artifactory/chartboost-ads/") }
 }
 
 publishing {


### PR DESCRIPTION
Latest version of CB SDK 9.3.0. Doesn't contain any breaking changes but requires 
      maven {
            url 'https://cboost.jfrog.io/artifactory/chartboost-ads/'
        }
repository to be added in the gradle to access the sdk. 