### PR TITLE
[Fyber] call static setMediationName and setMediationVersion from InneractiveAdManager

### DIFF
--- a/Fyber/src/main/java/com/applovin/mediation/adapters/InneractiveMediationAdapter.java
+++ b/Fyber/src/main/java/com/applovin/mediation/adapters/InneractiveMediationAdapter.java
@@ -227,8 +227,6 @@ public class InneractiveMediationAdapter
 
         interstitialSpot = InneractiveAdSpotManager.get().createSpot();
         interstitialSpot.addUnitController( controller );
-        interstitialSpot.setMediationName( "Max" );
-        interstitialSpot.setMediationVersion( AppLovinSdk.VERSION );
         interstitialSpot.setRequestListener( new InneractiveAdSpot.RequestListener()
         {
             @Override
@@ -389,8 +387,6 @@ public class InneractiveMediationAdapter
 
         rewardedSpot = InneractiveAdSpotManager.get().createSpot();
         rewardedSpot.addUnitController( controller );
-        rewardedSpot.setMediationName( "Max" );
-        rewardedSpot.setMediationVersion( AppLovinSdk.VERSION );
         rewardedSpot.setRequestListener( new InneractiveAdSpot.RequestListener()
         {
             @Override
@@ -518,8 +514,6 @@ public class InneractiveMediationAdapter
 
         adViewSpot = InneractiveAdSpotManager.get().createSpot();
         adViewSpot.addUnitController( controller );
-        adViewSpot.setMediationName( "Max" );
-        adViewSpot.setMediationVersion( AppLovinSdk.VERSION );
         adViewSpot.setRequestListener( new InneractiveAdSpot.RequestListener()
         {
             @Override
@@ -601,6 +595,9 @@ public class InneractiveMediationAdapter
         {
             InneractiveAdManager.currentAudienceAppliesToCoppa();
         }
+
+        InneractiveAdManager.setMediationName( "Max" );
+        InneractiveAdManager.setMediationVersion( AppLovinSdk.VERSION );
     }
 
     private static MaxAdapterError toMaxError(final InneractiveErrorCode inneractiveErrorCode)


### PR DESCRIPTION
[Fyber] call static setMediationName and setMediationVersion from InneractiveAdManager
1. call InneractiveAdManager.setMediationName() and InneractiveAdManger.setMediationVersion() instead of using the spot object
2. moved setMediationName and setMediationVersion calls to updateUserInfo method to reduce duplication