### PR TITLE
Update HyprMX Android adapter to set consent without considering age restricted user

### DIFF
--- a/ByteDance/CHANGELOG.md
+++ b/ByteDance/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 5.2.0.6.0
+* Certified with ByteDance SDK 5.2.0.6.
+
 ## 5.2.0.5.0
 * Certified with ByteDance SDK 5.2.0.5.
 

--- a/ByteDance/build.gradle.kts
+++ b/ByteDance/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 private val versionMajor = 5
 private val versionMinor = 2
 private val versionPatch = 0
-private val versionBuild = 5
+private val versionBuild = 6
 private val versionAdapterPatch = 0
 
 val libraryVersionName by extra("${versionMajor}.${versionMinor}.${versionPatch}.${versionBuild}.${versionAdapterPatch}")


### PR DESCRIPTION
Age restricted user is now passed as part of initialization, so it doesn't need to be a part of consent.