### PR TITLE
Mintegral/AOA_Bidding

### DIFF
--- a/Mintegral/CHANGELOG.md
+++ b/Mintegral/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 16.6.51.2
+* Add support for app open ads.
+
 ## 16.6.51.1
 * Remove ProGuard rules since they are included in Mintegral's libraries.
 

--- a/Mintegral/build.gradle.kts
+++ b/Mintegral/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 private val versionMajor = 16
 private val versionMinor = 6
 private val versionPatch = 51
-private val versionAdapterPatch = 1
+private val versionAdapterPatch = 2
 
 val libraryVersionName by extra("${versionMajor}.${versionMinor}.${versionPatch}.${versionAdapterPatch}")
 val libraryVersionCode by extra((versionMajor * 1000000) + (versionMinor * 10000) + (versionPatch * 100) + versionAdapterPatch)
@@ -37,6 +37,7 @@ dependencies {
     implementation("com.mbridge.msdk.oversea:videojs:${libraryVersions["mintegral"]}")
     implementation("com.mbridge.msdk.oversea:mbnative:${libraryVersions["mintegral"]}")
     implementation("com.mbridge.msdk.oversea:dycreator:${libraryVersions["mintegral"]}")
+    implementation("com.mbridge.msdk.oversea:mbsplash:${libraryVersions["mintegral"]}")
 
     implementation("androidx.recyclerview:recyclerview:${libraryVersions["recyclerView"]}")
 }


### PR DESCRIPTION
## Description
The `onDismiss` callback is invoked properly when countdown finishes, ad is skipped, or ad is clicked. However, the app open ad is unable to visually dismiss. Attempts to resolve the issue:
- Used main thread to initialize SDK, load + show ad
- Adjusted `canSkip` and `defCountdownS` upon splash handler creation

https://github.com/AppLovin/AppLovin-MAX-SDK-Android/assets/53385072/0a41b733-609d-47ba-a164-ec942e2268b1

