### PR TITLE
refactor/set_listeners_to_null_instead_of_destroying_adviews

### DIFF
--- a/AppLovin MAX Demo App - Java/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/InterstitialAdActivity.java
+++ b/AppLovin MAX Demo App - Java/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/InterstitialAdActivity.java
@@ -53,6 +53,7 @@ public class InterstitialAdActivity
     protected void onDestroy()
     {
         super.onDestroy();
+
         interstitialAd.setListener( null );
         interstitialAd.setRevenueListener( null );
     }

--- a/AppLovin MAX Demo App - Java/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/InterstitialAdActivity.java
+++ b/AppLovin MAX Demo App - Java/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/InterstitialAdActivity.java
@@ -53,7 +53,8 @@ public class InterstitialAdActivity
     protected void onDestroy()
     {
         super.onDestroy();
-        interstitialAd.destroy();
+        interstitialAd.setListener( null );
+        interstitialAd.setRevenueListener( null );
     }
 
     public void onShowAdClicked(View view)

--- a/AppLovin MAX Demo App - Java/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/RewardedAdActivity.java
+++ b/AppLovin MAX Demo App - Java/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/RewardedAdActivity.java
@@ -54,6 +54,7 @@ public class RewardedAdActivity
     protected void onDestroy()
     {
         super.onDestroy();
+
         rewardedAd.setListener( null );
         rewardedAd.setRevenueListener( null );
     }

--- a/AppLovin MAX Demo App - Java/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/RewardedAdActivity.java
+++ b/AppLovin MAX Demo App - Java/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/RewardedAdActivity.java
@@ -54,7 +54,8 @@ public class RewardedAdActivity
     protected void onDestroy()
     {
         super.onDestroy();
-        rewardedAd.destroy();
+        rewardedAd.setListener( null );
+        rewardedAd.setRevenueListener( null );
     }
 
     public void onShowAdClicked(View view)

--- a/AppLovin MAX Demo App - Kotlin/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/InterstitialAdActivity.kt
+++ b/AppLovin MAX Demo App - Kotlin/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/InterstitialAdActivity.kt
@@ -45,7 +45,8 @@ class InterstitialAdActivity : BaseAdActivity(),
 
     override fun onDestroy() {
         super.onDestroy()
-        interstitialAd.destroy()
+        interstitialAd.setListener(null)
+        interstitialAd.setRevenueListener(null)
     }
 
     fun showAd(view: View) {

--- a/AppLovin MAX Demo App - Kotlin/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/InterstitialAdActivity.kt
+++ b/AppLovin MAX Demo App - Kotlin/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/InterstitialAdActivity.kt
@@ -45,6 +45,7 @@ class InterstitialAdActivity : BaseAdActivity(),
 
     override fun onDestroy() {
         super.onDestroy()
+
         interstitialAd.setListener(null)
         interstitialAd.setRevenueListener(null)
     }

--- a/AppLovin MAX Demo App - Kotlin/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/RewardedAdActivity.kt
+++ b/AppLovin MAX Demo App - Kotlin/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/RewardedAdActivity.kt
@@ -42,7 +42,8 @@ class RewardedAdActivity : BaseAdActivity(),
 
     override fun onDestroy() {
         super.onDestroy()
-        rewardedAd.destroy()
+        rewardedAd.setListener(null)
+        rewardedAd.setRevenueListener(null)
     }
 
     fun showAd(view: View) {

--- a/AppLovin MAX Demo App - Kotlin/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/RewardedAdActivity.kt
+++ b/AppLovin MAX Demo App - Kotlin/app/src/main/java/com/applovin/enterprise/apps/demoapp/ads/max/RewardedAdActivity.kt
@@ -42,6 +42,7 @@ class RewardedAdActivity : BaseAdActivity(),
 
     override fun onDestroy() {
         super.onDestroy()
+
         rewardedAd.setListener(null)
         rewardedAd.setRevenueListener(null)
     }


### PR DESCRIPTION
Should just set the listeners to `null` instead of calling `destroy()`. I tested both the Kotlin and Java demo apps, and the memory leak is still gone with this code change. 