### PR TITLE
Adapter for Maio SDK 2.0.0

### DIFF
--- a/Maio/build.gradle.kts
+++ b/Maio/build.gradle.kts
@@ -8,7 +8,7 @@ afterEvaluate {
     apply(plugin = "adapter-publish")
 }
 
-val libraryVersionName by extra("1.1.16.3")
+val libraryVersionName by extra("2.0.0.0")
 
 repositories {
     maven { url = uri("https://imobile-maio.github.io/maven") }

--- a/Maio/src/main/AndroidManifest.xml
+++ b/Maio/src/main/AndroidManifest.xml
@@ -3,12 +3,10 @@
     <application>
         <activity
             android:name="jp.maio.sdk.android.v2.AdActivity"
-            android:configChanges="orientation|screenLayout|screenSize"
             android:hardwareAccelerated="true"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"></activity>
         <activity
             android:name="jp.maio.sdk.android.v2.PlayableActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"></activity>
     </application>
 </manifest>

--- a/Maio/src/main/AndroidManifest.xml
+++ b/Maio/src/main/AndroidManifest.xml
@@ -2,12 +2,12 @@
 
     <application>
         <activity
-            android:name="jp.maio.sdk.android.AdFullscreenActivity"
+            android:name="jp.maio.sdk.android.v2.AdActivity"
             android:configChanges="orientation|screenLayout|screenSize"
             android:hardwareAccelerated="true"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"></activity>
         <activity
-            android:name="jp.maio.sdk.android.HtmlBasedAdActivity"
+            android:name="jp.maio.sdk.android.v2.PlayableActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:theme="@android:style/Theme.NoTitleBar.Fullscreen"></activity>
     </application>

--- a/Maio/src/main/java/com/applovin/mediation/adapters/MaioMediationAdapter.java
+++ b/Maio/src/main/java/com/applovin/mediation/adapters/MaioMediationAdapter.java
@@ -50,7 +50,7 @@ public class MaioMediationAdapter
     @Override
     public String getSdkVersion()
     {
-        return Version.Companion.toString();
+        return Version.Companion.getInstance().toString();
     }
 
     @Override


### PR DESCRIPTION
Update Maio adapter to call maio SDK v2.0.0.
We could not fix it because `build.gradle.kts` have no dependencies, but our library name has changed.

- v1: `com.maio:android-sdk:1.x.x`
- v2: `com.maio:android-sdk-v2:2.0.0`