### PR TITLE
Set operations-per-run as 250 for the stale action

### DIFF
--- a/.github/workflows/issue_stale.yml
+++ b/.github/workflows/issue_stale.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
+          operations-per-run: 250
           exempt-issue-labels: "in progress"
           days-before-pr-stale: -1
           days-before-pr-close: -1


### PR DESCRIPTION
This PR sets operations-per-run to 250 for the GitHub stale action in the `issue_stale.yml` workflow file.