### PR TITLE
Fix maio SDK Missing in Mediation Debugger

### DIFF
--- a/Maio/proguard-rules.pro
+++ b/Maio/proguard-rules.pro
@@ -21,4 +21,4 @@
 -dontwarn android.app.Activity
 
 # For Mediation Debugger support
--keepnames class jp.maio.sdk.android.*
+-keepnames class jp.maio.sdk.android.**


### PR DESCRIPTION
maio SDK is now v2 with this PR https://github.com/AppLovin/AppLovin-MAX-SDK-Android/pull/704.

At that time, maio's package structure also seems to have changed.
- v1: `jp.maio.sdk.android.xxx`
- v2: `jp.maio.sdk.android.v2.xxx`

The changes were not reflected in proguard-rules.pro, and the SDK seemed to be missing in the mediation debugger, so I fixed it.

<img src=https://github.com/user-attachments/assets/02a9e0a7-140a-4439-8ae5-c348c39f18d3 width=300 />

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Modify the proguard-rules file to ensure complete keepnames coverage of all classes within the `jp.maio.sdk.android` package and its sub-packages for proper mediation debugger support.

### Why are these changes being made?

The change addresses the issue of the maio SDK being missing in the mediation debugger by refining the ProGuard rules to prevent obfuscation of all classes within the specified package, which ensures proper visibility and integration in debugging scenarios.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->