### PR TITLE
[MobileFuse] Set the Adapter version using the MobileFuseSettings and update the setTesMode

### DIFF
--- a/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
+++ b/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
@@ -76,7 +76,7 @@ public class MobileFuseMediationAdapter
                 MobileFuseSettings.setTestMode( isTesting );
             }
 
-            MobileFuseSettings.setSdkAdapter( "applovin_custom", getAdapterVersion() );
+            MobileFuseSettings.setSdkAdapter( "applovin_bidding", getAdapterVersion() );
 
             MobileFuse.init( new SdkInitListener()
             {

--- a/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
+++ b/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
@@ -70,7 +70,13 @@ public class MobileFuseMediationAdapter
             log( "Initializing MobileFuse SDK" );
             initializationStatus = InitializationStatus.INITIALIZING;
 
-            MobileFuseSettings.setTestMode( parameters.isTesting() );
+            boolean isTesting = parameters.isTesting();
+
+            if (isTesting) {
+                MobileFuseSettings.setTestMode( isTesting );
+            }
+
+            MobileFuseSettings.setSdkAdapter( "applovin_custom", getAdapterVersion() );
 
             MobileFuse.init( new SdkInitListener()
             {


### PR DESCRIPTION
Update for MobileFuse:

1. Set the adapter version using MobileFuseSettings

2. To match IOs, setTestMode ONLY if the testMode is true

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Update the `MobileFuseMediationAdapter` to set the adapter version using `MobileFuseSettings` and modify the execution of `setTestMode` to be conditional based on the test mode flag.

### Why are these changes being made?

These changes leverage the `MobileFuseSettings` to explicitly set the SDK adapter version, enhancing tracking and version management. Additionally, updating the `setTestMode` method to execute conditionally prevents unnecessary method calls when not in testing mode, which can improve runtime efficiency and avoid potential errors.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->