### PR TITLE
MobileFuse Adapter 1.8.2.1

### DIFF
--- a/MobileFuse/CHANGELOG.md
+++ b/MobileFuse/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.8.2.1
+* Added support for an optional listener in Native Ads.
+
 ## 1.8.2.0
 * Certified with MobileFuse SDK 1.8.2.
 

--- a/MobileFuse/CHANGELOG.md
+++ b/MobileFuse/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.8.2.1
 * Added support for an optional listener in Native Ads.
-* Set Adapter version via `MobileFuseSettings` and updated `setTestMode` logic.
+* Set Adapter version via `MobileFuseSettings`.
 
 ## 1.8.2.0
 * Certified with MobileFuse SDK 1.8.2.

--- a/MobileFuse/CHANGELOG.md
+++ b/MobileFuse/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.8.2.1
 * Added support for an optional listener in Native Ads.
+* Set Adapter version via `MobileFuseSettings` and updated `setTestMode` logic.
 
 ## 1.8.2.0
 * Certified with MobileFuse SDK 1.8.2.

--- a/MobileFuse/build.gradle.kts
+++ b/MobileFuse/build.gradle.kts
@@ -6,7 +6,7 @@ afterEvaluate {
     apply(plugin = "adapter-publish")
 }
 
-val libraryVersionName by extra("1.8.2.0")
+val libraryVersionName by extra("1.8.2.1")
 
 android.defaultConfig.minSdk = 19
 

--- a/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
+++ b/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
@@ -134,7 +134,7 @@ public class MobileFuseMediationAdapter
         if ( nativeAd != null )
         {
             nativeAd.unregisterViews();
-            nativeAd.setListener( null );
+            nativeAd.setAdListener( null );
             nativeAd = null;
         }
     }
@@ -254,7 +254,7 @@ public class MobileFuseMediationAdapter
         if ( isNative )
         {
             nativeAd = new MobileFuseNativeAd( getContext( activity ), placementId );
-            nativeAd.setListener( new NativeAdViewListener( adFormat, parameters, listener ) );
+            nativeAd.setAdListener( new NativeAdViewListener( adFormat, parameters, listener ) );
             nativeAd.loadAdFromBiddingToken( parameters.getBidResponse() );
         }
         else
@@ -281,7 +281,7 @@ public class MobileFuseMediationAdapter
         updatePrivacyPreferences( parameters );
 
         nativeAd = new MobileFuseNativeAd( getContext( activity ), placementId );
-        nativeAd.setListener( new NativeAdListener( parameters, listener ) );
+        nativeAd.setAdListener( new NativeAdListener( parameters, listener ) );
         nativeAd.loadAdFromBiddingToken( parameters.getBidResponse() );
     }
 

--- a/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
+++ b/MobileFuse/src/main/java/com/applovin/mediation/adapters/MobileFuseMediationAdapter.java
@@ -70,12 +70,7 @@ public class MobileFuseMediationAdapter
             log( "Initializing MobileFuse SDK" );
             initializationStatus = InitializationStatus.INITIALIZING;
 
-            boolean isTesting = parameters.isTesting();
-
-            if (isTesting) {
-                MobileFuseSettings.setTestMode( isTesting );
-            }
-
+            MobileFuseSettings.setTestMode( parameters.isTesting() );
             MobileFuseSettings.setSdkAdapter( "applovin_bidding", getAdapterVersion() );
 
             MobileFuse.init( new SdkInitListener()


### PR DESCRIPTION
Changes:
- Added support for an optional listener in Native Ads.
- Set Adapter version via `MobileFuseSettings`.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Implement version 1.8.2.1 of the MobileFuse Adapter, featuring the addition of support for an optional listener in Native Ads, setting the Adapter version through `MobileFuseSettings`, and updating the logic for `setTestMode`.

### Why are these changes being made?

These changes are being made to enhance the MobileFuse Adapter with new capabilities, such as supporting optional listeners for Native Ads, which can improve flexibility and control. The updates to `MobileFuseSettings` for setting adapter version and optimizing the `setTestMode` logic provide cleaner implementation and potential stability improvements. This release aligns with maintaining compatibility and functionality for enhancements in the MobileFuse SDK environment.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->