### PR TITLE
PubMatic Adapter v4.4.0.1 gpid support and updated logic for destroy Method

### DIFF
--- a/PubMatic/CHANGELOG.md
+++ b/PubMatic/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.4.0.1
 * Updated to support gpid (Global Placement ID)
+* invoking destroy() call on Mainthread to resolve NPE issue
 
 ## 4.4.0.0
 * Certified with PubMatic SDK 4.4.0.

--- a/PubMatic/CHANGELOG.md
+++ b/PubMatic/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.4.0.1
+* Updated to support gpid (Global Placement ID)
+
 ## 4.4.0.0
 * Certified with PubMatic SDK 4.4.0.
 

--- a/PubMatic/CHANGELOG.md
+++ b/PubMatic/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 4.4.0.1
 * Updated to support gpid (Global Placement ID)
-* invoking destroy() call on Mainthread to resolve NPE issue
+* Invoking destroy() call on Mainthread to resolve NPE issue
 
 ## 4.4.0.0
 * Certified with PubMatic SDK 4.4.0.

--- a/PubMatic/CHANGELOG.md
+++ b/PubMatic/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## 4.4.0.1
-* Updated to support gpid (Global Placement ID)
-* Invoking destroy() call on Mainthread to resolve NPE issue
+* Updated to support gpid (Global Placement ID).
+* Invoking destroy() method on MainThread to resolve intermittent NPE's.
 
 ## 4.4.0.0
 * Certified with PubMatic SDK 4.4.0.

--- a/PubMatic/build.gradle.kts
+++ b/PubMatic/build.gradle.kts
@@ -6,7 +6,7 @@ afterEvaluate {
     apply(plugin = "adapter-publish")
 }
 
-val libraryVersionName by extra("4.4.0.0")
+val libraryVersionName by extra("4.4.0.1")
 
 android.defaultConfig.minSdk = 19
 

--- a/PubMatic/src/main/java/com/applovin/mediation/adapters/PubMaticMediationAdapter.java
+++ b/PubMatic/src/main/java/com/applovin/mediation/adapters/PubMaticMediationAdapter.java
@@ -6,6 +6,7 @@ import android.app.Activity;
 import com.applovin.impl.sdk.utils.BundleUtils;
 import com.applovin.mediation.MaxAdFormat;
 import com.applovin.mediation.MaxReward;
+import com.applovin.sdk.AppLovinSdkUtils;
 import com.applovin.mediation.adapter.MaxAdViewAdapter;
 import com.applovin.mediation.adapter.MaxAdapterError;
 import com.applovin.mediation.adapter.MaxInterstitialAdapter;
@@ -140,25 +141,29 @@ public class PubMaticMediationAdapter
     }
 
     @Override
-    public void onDestroy()
-    {
-        if ( interstitialAd != null )
-        {
-            interstitialAd.destroy();
-            interstitialAd = null;
-        }
+    public void onDestroy() {
+        AppLovinSdkUtils.runOnUiThread(new Runnable() {
+            @Override
+            public void run() {
+                if ( interstitialAd != null )
+                {
+                    interstitialAd.destroy();
+                    interstitialAd = null;
+                }
 
-        if ( rewardedAd != null )
-        {
-            rewardedAd.destroy();
-            rewardedAd = null;
-        }
+                if ( rewardedAd != null )
+                {
+                    rewardedAd.destroy();
+                    rewardedAd = null;
+                }
 
-        if ( adView != null )
-        {
-            adView.destroy();
-            adView = null;
-        }
+                if ( adView != null )
+                {
+                    adView.destroy();
+                    adView = null;
+                }
+            }
+        });
     }
 
     @SuppressLint("MissingPermission")

--- a/PubMatic/src/main/java/com/applovin/mediation/adapters/PubMaticMediationAdapter.java
+++ b/PubMatic/src/main/java/com/applovin/mediation/adapters/PubMaticMediationAdapter.java
@@ -117,7 +117,7 @@ public class PubMaticMediationAdapter
             return;
         }
 
-        final POBSignalConfig config = new POBSignalConfig.Builder( adFormat ).build();
+        final POBSignalConfig config = new POBSignalConfig.Builder( adFormat ).setGpid( parameters.getAdUnitId() ).build();
         final String bidToken = POBSignalGenerator.generateSignal( getApplicationContext(), POBBiddingHost.ALMAX, config );
 
         callback.onSignalCollected( bidToken );

--- a/PubMatic/src/main/java/com/applovin/mediation/adapters/PubMaticMediationAdapter.java
+++ b/PubMatic/src/main/java/com/applovin/mediation/adapters/PubMaticMediationAdapter.java
@@ -6,7 +6,6 @@ import android.app.Activity;
 import com.applovin.impl.sdk.utils.BundleUtils;
 import com.applovin.mediation.MaxAdFormat;
 import com.applovin.mediation.MaxReward;
-import com.applovin.sdk.AppLovinSdkUtils;
 import com.applovin.mediation.adapter.MaxAdViewAdapter;
 import com.applovin.mediation.adapter.MaxAdapterError;
 import com.applovin.mediation.adapter.MaxInterstitialAdapter;
@@ -26,6 +25,7 @@ import com.pubmatic.sdk.common.OpenWrapSDKConfig;
 import com.pubmatic.sdk.common.OpenWrapSDKInitializer;
 import com.pubmatic.sdk.common.POBAdFormat;
 import com.pubmatic.sdk.common.POBError;
+import com.pubmatic.sdk.common.utility.POBUtils;
 import com.pubmatic.sdk.openwrap.banner.POBBannerView;
 import com.pubmatic.sdk.openwrap.core.POBReward;
 import com.pubmatic.sdk.openwrap.core.signal.POBBiddingHost;
@@ -142,7 +142,9 @@ public class PubMaticMediationAdapter
 
     @Override
     public void onDestroy() {
-        AppLovinSdkUtils.runOnUiThread(new Runnable() {
+        // Explicitly invoke OpenWrap SDKs destroy() API on main thread, to make sure OpenWrap SDK
+        // does not go into race condition.
+        POBUtils.runOnMainThread(new Runnable() {
             @Override
             public void run() {
                 if ( interstitialAd != null )


### PR DESCRIPTION
This PR contains

- Updated adapter version to 4.4.0.1
- Updated to support gpid (Global Placement ID).
- Invoking destroy() method on MainThread to resolve intermittent NPE's.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add GPID (Global Placement ID) support to the PubMatic adapter and ensure the destroy method is invoked on the main thread to prevent intermittent NullPointerExceptions.

### Why are these changes being made?
These updates address the need for identifying ad placements accurately with GPID and resolve potential threading issues causing race conditions by ensuring that the destruction of ads occurs on the main thread. This optimizes the reliability and functionality of the PubMatic adapter version 4.4.0.1.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->