### PR TITLE
Update MintegralMediationAdapter.java

### DIFF
--- a/Mintegral/src/main/java/com/applovin/mediation/adapters/MintegralMediationAdapter.java
+++ b/Mintegral/src/main/java/com/applovin/mediation/adapters/MintegralMediationAdapter.java
@@ -417,6 +417,13 @@ public class MintegralMediationAdapter
     {
         router.addShowingAdapter( this );
 
+        //Fix the issue where callbacks are not received when the listener is set to null.
+        if (mbBidInterstitialVideoHandler != null) {
+            mbBidInterstitialVideoHandler.setInterstitialVideoListener( router.getInterstitialListener() );
+        } else if (mbInterstitialVideoHandler != null) {
+            mbBidInterstitialVideoHandler.setInterstitialVideoListener( router.getInterstitialListener() );
+        }
+
         if ( mbBidInterstitialVideoHandler != null && mbBidInterstitialVideoHandler.isBidReady() )
         {
             log( "Showing bidding interstitial..." );
@@ -577,6 +584,13 @@ public class MintegralMediationAdapter
         final Bundle serverParameters = parameters.getServerParameters();
         final String rewardId = serverParameters.getString( "reward_id", "" );
         final String userId = serverParameters.getString( "user_id", "" );
+
+        //Fix the issue where callbacks are not received when the listener is set to null.
+        if (mbBidRewardVideoHandler != null) {
+            mbBidRewardVideoHandler.setRewardVideoListener( router.getRewardedListener() );
+        } else if (mbRewardVideoHandler != null) {
+            mbRewardVideoHandler.setRewardVideoListener( router.getRewardedListener() );
+        }
 
         if ( mbBidRewardVideoHandler != null && mbBidRewardVideoHandler.isBidReady() )
         {


### PR DESCRIPTION
Fix the reduced show success callback rate when MTG multi-cache is enabled

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add logic to ensure callbacks are set to appropriate listeners for interstitial and rewarded ad handlers in `MintegralMediationAdapter.java`.

### Why are these changes being made?

These changes fix an issue where callbacks were not being received when the listener was set to null, ensuring the ad handlers work as intended. This approach adds necessary checks and assigns correct listeners to address the problem effectively.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->