### PR TITLE
Update YandexMediationAdapter.java

### DIFF
--- a/Yandex/src/main/java/com/applovin/mediation/adapters/YandexMediationAdapter.java
+++ b/Yandex/src/main/java/com/applovin/mediation/adapters/YandexMediationAdapter.java
@@ -247,17 +247,6 @@ public class YandexMediationAdapter
         final String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( AppLovinSdkUtils.isValidString( parameters.getBidResponse() ) ? "bidding " : "" ) + "interstitial ad for placement: " + placementId + "..." );
 
-        // Yandex team advises passing in an `Activity` context to fix any launcher task issues
-        if ( activity == null )
-        {
-            log( "Interstitial ad load failed: Activity is null" );
-
-            final MaxAdapterError error = new MaxAdapterError( -5601, "Missing Activity" );
-            listener.onInterstitialAdLoadFailed( error );
-
-            return;
-        }
-
         updatePrivacySettings( parameters );
 
         Runnable loadInterstitialAdRunnable = new Runnable()
@@ -307,17 +296,6 @@ public class YandexMediationAdapter
     {
         final String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( AppLovinSdkUtils.isValidString( parameters.getBidResponse() ) ? "bidding " : "" ) + "rewarded ad for placement: " + placementId + "..." );
-
-        // Yandex team advises passing in an `Activity` context to fix any launcher task issues
-        if ( activity == null )
-        {
-            log( "Rewarded ad load failed: Activity is null" );
-
-            final MaxAdapterError error = new MaxAdapterError( -5601, "Missing Activity" );
-            listener.onRewardedAdLoadFailed( error );
-
-            return;
-        }
 
         updatePrivacySettings( parameters );
 


### PR DESCRIPTION
Hello!
Yandex Mobile Ads SDK can load ad with application context too. This check is obsolete.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Remove the requirement to pass an `Activity` context during the loading of interstitial and rewarded ads in the `YandexMediationAdapter`.

### Why are these changes being made?

These changes are based on updated guidance from the Yandex team, indicating that the `Activity` context check is no longer necessary for resolving launcher task issues. This simplifies the ad loading process by removing redundant error handling.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->