### PR TITLE
UnityAds 4.15.0 getToken update

### DIFF
--- a/UnityAds/src/main/java/com/applovin/mediation/adapters/UnityAdsMediationAdapter.java
+++ b/UnityAds/src/main/java/com/applovin/mediation/adapters/UnityAdsMediationAdapter.java
@@ -21,6 +21,7 @@ import com.applovin.mediation.adapter.parameters.MaxAdapterSignalCollectionParam
 import com.applovin.mediation.adapters.unityads.BuildConfig;
 import com.applovin.sdk.AppLovinSdk;
 import com.applovin.sdk.AppLovinSdkUtils;
+import com.unity3d.ads.AdFormat;
 import com.unity3d.ads.IUnityAdsInitializationListener;
 import com.unity3d.ads.IUnityAdsLoadListener;
 import com.unity3d.ads.IUnityAdsShowListener;
@@ -132,15 +133,37 @@ public class UnityAdsMediationAdapter
 
         updatePrivacyConsent( parameters, getContext( activity ) );
 
-        UnityAds.getToken( new IUnityAdsTokenListener()
-        {
+        AdFormat unityAdFormat = toAdFormat(parameters);
+
+        IUnityAdsTokenListener unityAdsTokenListener = new IUnityAdsTokenListener() {
             @Override
-            public void onUnityAdsTokenReady(final String token)
-            {
-                log( "Collected signal" );
-                callback.onSignalCollected( token );
+            public void onUnityAdsTokenReady(final String token) {
+                log("Collected signal: " + token);
+                callback.onSignalCollected(token);
             }
-        } );
+        };
+
+        if (unityAdFormat == null) {
+            UnityAds.getToken(unityAdsTokenListener);
+        } else {
+            UnityAds.getToken(new TokenConfiguration(unityAdFormat, unityAdsTokenListener);
+        }
+    }
+
+    private AdFormat toAdFormat(final MaxAdapterSignalCollectionParameters parameters)
+    {
+        MaxAdFormat adFormat = parameters.getAdFormat();
+        AdFormat unityAdFormat = null;
+        if (parameters.isAdViewAd()) {
+            adFormat = MaxAdFormat.BANNER;
+        } else if ( adFormat == MaxAdFormat.INTERSTITIAL ) {
+            unityAdFormat = AdFormat.INTERSTITIAL;
+        } else if ( adFormat == MaxAdFormat.REWARDED ) {
+            unityAdFormat = AdFormat.REWARDED;
+        } else {
+            log("Unsupported ad format encountered: " + adFormat);
+        }
+        return unityAdFormat;
     }
 
     @Override


### PR DESCRIPTION
- Gets `MaxAdFormat` from the `MaxAdapterSignalCollectionParameters` configuration
- Converts the `MaxAdFormat` from to Unity's AdFormat
- Pass the AdFormat to `getToken` call to optimize ad loading processes for faster ad delivery

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Introduce a `TokenConfiguration` object in the `UnityAds.getToken` method and add a `toAdFormat` helper method to map `MaxAdFormat` to `AdFormat`.

### Why are these changes being made?
The update to UnityAds 4.15.0 requires the use of `TokenConfiguration` for the `getToken` method, ensuring proper configuration of the ad formats. The newly added `toAdFormat` method cleanly handles and validates the conversion of `MaxAdapterSignalCollectionParameters` to `AdFormat`, which is essential for supporting multiple ad formats and maintaining code readability.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->