### PR TITLE
Fix for MediaView to be guaranteed in the hierarchy

### DIFF
--- a/Yandex/src/main/java/com/applovin/mediation/adapters/YandexMediationAdapter.java
+++ b/Yandex/src/main/java/com/applovin/mediation/adapters/YandexMediationAdapter.java
@@ -31,6 +31,7 @@ import com.applovin.mediation.adapter.parameters.MaxAdapterInitializationParamet
 import com.applovin.mediation.adapter.parameters.MaxAdapterParameters;
 import com.applovin.mediation.adapter.parameters.MaxAdapterResponseParameters;
 import com.applovin.mediation.adapter.parameters.MaxAdapterSignalCollectionParameters;
+import com.applovin.mediation.adapters.yandex.BuildConfig;
 import com.applovin.mediation.nativeAds.MaxNativeAd;
 import com.applovin.mediation.nativeAds.MaxNativeAdView;
 import com.applovin.sdk.AppLovinSdk;
@@ -78,8 +79,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 /**
- * AppLovin themselves support this adapter, it was added here to test integration and help publishers
- * Taken from: <a href="https://github.com/AppLovin/AppLovin-MAX-SDK-Android/blob/master/Yandex/src/main/java/com/applovin/mediation/adapters/YandexMediationAdapter.java">...</a>
+ * Created by Andrew Tian on 9/16/19.
  */
 public class YandexMediationAdapter
         extends MediationAdapterBase
@@ -99,7 +99,7 @@ public class YandexMediationAdapter
     {
         {
             put( "adapter_network_name", "applovin" );
-            put( "adapter_version", MobileAds.getLibraryVersion() + ".0" );
+            put( "adapter_version", BuildConfig.VERSION_NAME );
             put( "adapter_network_sdk_version", AppLovinSdk.VERSION );
         }
     };
@@ -129,7 +129,7 @@ public class YandexMediationAdapter
     @Override
     public String getAdapterVersion()
     {
-        return MobileAds.getLibraryVersion() + ".0";
+        return BuildConfig.VERSION_NAME;
     }
 
     // @Override
@@ -274,8 +274,8 @@ public class YandexMediationAdapter
         {
             log( "Interstitial ad failed to show - ad not ready" );
             listener.onInterstitialAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                    MaxAdapterError.AD_NOT_READY.getCode(),
-                    MaxAdapterError.AD_NOT_READY.getMessage() ) );
+                                                                         MaxAdapterError.AD_NOT_READY.getCode(),
+                                                                         MaxAdapterError.AD_NOT_READY.getMessage() ) );
             return;
         }
 
@@ -326,8 +326,8 @@ public class YandexMediationAdapter
         {
             log( "Rewarded ad failed to show - ad not ready" );
             listener.onRewardedAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                    MaxAdapterError.AD_NOT_READY.getCode(),
-                    MaxAdapterError.AD_NOT_READY.getMessage() ) );
+                                                                     MaxAdapterError.AD_NOT_READY.getCode(),
+                                                                     MaxAdapterError.AD_NOT_READY.getMessage() ) );
             return;
         }
 
@@ -580,27 +580,6 @@ public class YandexMediationAdapter
         return BannerAdSize.fixedSize( context, adaptiveAdWidth, anchoredHeight );
     }
 
-    // Stub getAdaptiveAdViewWidth
-    private static Integer getAdaptiveAdViewWidth(final MaxAdapterParameters parameters, final Context context) {
-        return 320;
-    }
-
-    // Stub getInlineAdaptiveAdViewMaximumHeight
-    private static Integer getInlineAdaptiveAdViewMaximumHeight(final MaxAdapterParameters parameters) {
-        return 300;
-    }
-
-    // Stub isInlineAdaptiveAdView
-    private static Boolean isInlineAdaptiveAdView(final MaxAdapterParameters parameters) {
-        return false;
-    }
-
-    // Stub isAdaptiveAdViewFormat
-    private static Boolean isAdaptiveAdViewFormat(final MaxAdFormat adFormat,
-                                                  final MaxAdapterParameters parameters) {
-        return false;
-    }
-
     private static MaxAdapterError toMaxError(final AdRequestError yandexError)
     {
         final int yandexErrorCode = yandexError.getCode();
@@ -687,8 +666,8 @@ public class YandexMediationAdapter
         {
             log( "Interstitial ad failed to show with error description: " + adError.getDescription() );
             listener.onInterstitialAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                    0,
-                    adError.getDescription() ) );
+                                                                         0,
+                                                                         adError.getDescription() ) );
         }
 
         @Override
@@ -763,8 +742,8 @@ public class YandexMediationAdapter
         {
             log( "Rewarded ad failed to show with error description: " + adError.getDescription() );
             listener.onRewardedAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                    0,
-                    adError.getDescription() ) );
+                                                                     0,
+                                                                     adError.getDescription() ) );
         }
 
         @Override


### PR DESCRIPTION
The bug was that the Yandex MediaView was not explicitly inserted into the AppLovin layout container and remained without valid dimensions. We looked at the implementation for another adapter and fixed it by analogy. Now the MediaView is guaranteed to be in the hierarchy, receives valid dimensions, and renders stably in native.

### Before
<img width="380" height="285" alt="before" src="https://github.com/user-attachments/assets/9f9dcf47-c46f-4e4a-922c-84030eebd7e8" />

### After
<img width="381" height="455" alt="after" src="https://github.com/user-attachments/assets/10cfc3de-2160-4211-b936-49e77bf587e9" />

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Ensure the Yandex MediaView is attached to the media container with proper `LayoutParams` within the `YandexMediationAdapter.java` and update the adapter version retrieval logic.

### Why are these changes being made?
The change enhances the integration between Yandex native ads and AppLovin by ensuring the MediaView is correctly placed in the view hierarchy, addressing display issues. The adapter version retrieval is updated to align with the library version from MobileAds instead of relying on a static BuildConfig version.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->