### PR TITLE
Liftoff 7.7.6.1 adapter release (#27)

### DIFF
--- a/Vungle/CHANGELOG.md
+++ b/Vungle/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 7.7.4.1
+* Adapter logging phase 2: removed `canPlayAd()` and SDK-initialization checks to let the Vungle SDK handle and log these cases, and added `VungleMediationLogger` logging for null ad instances, native ad object mismatch, and unspecified errors.
+
 ## 7.7.4.0
 * Certified with Vungle SDK 7.7.4.
 

--- a/Vungle/build.gradle.kts
+++ b/Vungle/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.applovin.mobile.publish")
 }
 
-val libraryVersionName by extra("7.7.4.0")
+val libraryVersionName by extra("7.7.4.1")
 val minAppLovinSdkVersion by extra("13.0.0")
 
 android.defaultConfig.minSdk = 16

--- a/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
+++ b/Vungle/src/main/java/com/applovin/mediation/adapters/VungleMediationAdapter.java
@@ -215,14 +215,6 @@ public class VungleMediationAdapter
         String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + "interstitial ad for placement: " + placementId + "..." );
 
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing interstitial ad load..." );
-            listener.onInterstitialAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
-
         updateUserPrivacySettings( parameters );
 
         interstitialAd = new InterstitialAd( getContext( activity ), placementId, new AdConfig() );
@@ -235,18 +227,17 @@ public class VungleMediationAdapter
     @Override
     public void showInterstitialAd(final MaxAdapterResponseParameters parameters, @Nullable final Activity activity, final MaxInterstitialAdapterListener listener)
     {
-        if ( interstitialAd != null && interstitialAd.canPlayAd() )
+        if ( interstitialAd == null )
         {
-            log( "Showing interstitial ad for placement: " + parameters.getThirdPartyAdPlacementId() + "..." );
-            interstitialAd.play( getContext( activity ) );
-        }
-        else
-        {
-            log( "Interstitial ad is not ready: " + parameters.getThirdPartyAdPlacementId() + "..." );
             listener.onInterstitialAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                                                                         MaxAdapterError.AD_NOT_READY.getCode(),
-                                                                         MaxAdapterError.AD_NOT_READY.getMessage() ) );
+                                                                          MaxAdapterError.AD_NOT_READY.getCode(),
+                                                                          MaxAdapterError.AD_NOT_READY.getMessage() ) );
+            VungleMediationLogger.logError( null, "Interstitial ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
+            return;
         }
+
+        log("Showing interstitial ad for placement: " + parameters.getThirdPartyAdPlacementId() + "...");
+        interstitialAd.play(getContext(activity));
     }
 
     //endregion
@@ -260,14 +251,6 @@ public class VungleMediationAdapter
         String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + "app open ad for placement: " + placementId + "..." );
 
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing app open ad load..." );
-            listener.onAppOpenAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
-
         updateUserPrivacySettings( parameters );
 
         appOpenAd = new InterstitialAd( getContext( activity ), placementId, new AdConfig() );
@@ -279,18 +262,17 @@ public class VungleMediationAdapter
 
     public void showAppOpenAd(@NonNull final MaxAdapterResponseParameters parameters, @Nullable final Activity activity, @NonNull final MaxAppOpenAdapterListener listener)
     {
-        if ( appOpenAd != null && appOpenAd.canPlayAd() )
+        if ( appOpenAd == null )
         {
-            log( "Showing app open ad for placement: " + parameters.getThirdPartyAdPlacementId() + "..." );
-            appOpenAd.play( getContext( activity ) );
-        }
-        else
-        {
-            log( "App open ad is not ready: " + parameters.getThirdPartyAdPlacementId() + "..." );
             listener.onAppOpenAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                                                                    MaxAdapterError.AD_NOT_READY.getCode(),
-                                                                    MaxAdapterError.AD_NOT_READY.getMessage() ) );
+                                                                     MaxAdapterError.AD_NOT_READY.getCode(),
+                                                                     MaxAdapterError.AD_NOT_READY.getMessage() ) );
+            VungleMediationLogger.logError( null, "App open ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
+            return;
         }
+
+        log("Showing app open ad for placement: " + parameters.getThirdPartyAdPlacementId() + "...");
+        appOpenAd.play(getContext(activity));
     }
 
     //endregion
@@ -305,14 +287,6 @@ public class VungleMediationAdapter
         String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + "rewarded ad for placement: " + placementId + "..." );
 
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing rewarded ad load..." );
-            listener.onRewardedAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
-
         updateUserPrivacySettings( parameters );
 
         rewardedAd = new RewardedAd( getContext( activity ), placementId, new AdConfig() );
@@ -325,20 +299,18 @@ public class VungleMediationAdapter
     @Override
     public void showRewardedAd(final MaxAdapterResponseParameters parameters, @Nullable final Activity activity, final MaxRewardedAdapterListener listener)
     {
-        if ( rewardedAd != null && rewardedAd.canPlayAd() )
+        if ( rewardedAd == null )
         {
-            log( "Showing rewarded ad for placement: " + parameters.getThirdPartyAdPlacementId() + "..." );
-
-            configureReward( parameters );
-            rewardedAd.play( getContext( activity ) );
-        }
-        else
-        {
-            log( "Rewarded ad is not ready: " + parameters.getThirdPartyAdPlacementId() + "..." );
             listener.onRewardedAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                                                                     MaxAdapterError.AD_NOT_READY.getCode(),
-                                                                     MaxAdapterError.AD_NOT_READY.getMessage() ) );
+                                                                      MaxAdapterError.AD_NOT_READY.getCode(),
+                                                                      MaxAdapterError.AD_NOT_READY.getMessage() ) );
+            VungleMediationLogger.logError( null, "Rewarded ad instance is null: " + parameters.getThirdPartyAdPlacementId() );
+            return;
         }
+
+        log("Showing rewarded ad for placement: " + parameters.getThirdPartyAdPlacementId() + "...");
+        configureReward(parameters);
+        rewardedAd.play(getContext(activity));
     }
 
     //endregion
@@ -357,14 +329,6 @@ public class VungleMediationAdapter
         final boolean isNative = parameters.getServerParameters().getBoolean( "is_native" );
 
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + ( isNative ? "native " : "" ) + adFormatLabel + " ad for placement: " + placementId + "..." );
-
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing " + adFormatLabel + " ad load..." );
-            listener.onAdViewAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
 
         updateUserPrivacySettings( parameters );
 
@@ -420,14 +384,6 @@ public class VungleMediationAdapter
         boolean isBiddingAd = AppLovinSdkUtils.isValidString( bidResponse );
         String placementId = parameters.getThirdPartyAdPlacementId();
         log( "Loading " + ( isBiddingAd ? "bidding " : "" ) + "native ad for placement: " + placementId + "..." );
-
-        if ( shouldFailAdLoadWhenSdkNotInitialized( parameters ) && !VungleAds.isInitialized() )
-        {
-            log( "Vungle SDK not successfully initialized: failing interstitial ad load..." );
-            listener.onNativeAdLoadFailed( MaxAdapterError.NOT_INITIALIZED );
-
-            return;
-        }
 
         updateUserPrivacySettings( parameters );
 
@@ -630,6 +586,10 @@ public class VungleMediationAdapter
             case Reason.WEBVIEW_ERROR_VALUE:
                 adapterError = MaxAdapterError.WEBVIEW_ERROR;
                 break;
+        }
+
+        if (adapterError == MaxAdapterError.UNSPECIFIED) {
+            VungleMediationLogger.logError( null, "unspecifiedErrorCode:" +  vungleErrorCode);
         }
 
         return new MaxAdapterError( adapterError, vungleErrorCode, vungleError.getLocalizedMessage() );
@@ -999,6 +959,7 @@ public class VungleMediationAdapter
             {
                 log( "Native " + adFormat.getLabel() + " ad failed to load: no fill" );
                 listener.onAdViewAdLoadFailed( MaxAdapterError.NO_FILL );
+                VungleMediationLogger.logError( ad, "nativeAdObjectMismatch" );
 
                 return;
             }
@@ -1118,6 +1079,7 @@ public class VungleMediationAdapter
             {
                 log( "Native ad failed to load: no fill" );
                 listener.onNativeAdLoadFailed( MaxAdapterError.NO_FILL );
+                VungleMediationLogger.logError( ad, "nativeAdObjectMismatch" );
 
                 return;
             }
@@ -1128,6 +1090,7 @@ public class VungleMediationAdapter
             {
                 e( "Native ad (" + nativeAd + ") does not have required assets." );
                 listener.onNativeAdLoadFailed( MaxAdapterError.MISSING_REQUIRED_NATIVE_AD_ASSETS );
+                VungleMediationLogger.logError( ad, "missingRequiredNativeAdAssets" );
 
                 return;
             }
@@ -1217,12 +1180,6 @@ public class VungleMediationAdapter
             if ( nativeAd == null )
             {
                 e( "Failed to register native ad views: native ad is null." );
-                return false;
-            }
-
-            if ( !nativeAd.canPlayAd() )
-            {
-                e( "Failed to play native ad or native ad is registered." );
                 return false;
             }
 


### PR DESCRIPTION
- Removed canPlayAd check
Removed the `canPlayAd()` check before showing interstitial, app open, and rewarded ads so they are presented immediately. This lets the Liftoff SDK handle the case where an ad is not ready, fire its own display-failed callback to the adapter (and to the MAX SDK), and log the event properly and internally (to Liftoff). The `canPlayAd()` guard in native ad prepareForInteraction was removed as well.

- Removed SDK initialization check
Removed the local "fail ad load when SDK not initialized" check (the `shouldFailAdLoadWhenSdkNotInitialized` + `VungleAds.isInitialized()` guard) from all ad load paths — interstitial, app open, rewarded, ad view, and native. The load request is now always forwarded, allowing the Liftoff SDK to detect the un-initialized state, return the appropriate failure callback, and log the event properly and internally (to Liftoff).
If removing shouldFailAdLoadWhenSDKNotInitialized: helper and initialization check will be a problem for MAX side, let us know, so I will use Adapter Logging to cover this cases.

- Log Native Ad object mismatch case
Log the native ad object mismatch case for Liftoff SDK logging. When the loaded VungleNative object does not match the adapter's tracked native ad, the adapter now reports `nativeAdObjectMismatch` (and missingRequiredNativeAdAssets when assets are missing) through `VungleMediationLogger`, giving the Liftoff SDK visibility into these failures.

- Log `MaxAdapterError.UNSPECIFIED` case
Log the `MaxAdapterError.UNSPECIFIED` case for Liftoff SDK logging. When a Vungle error maps to no specific MAX error code, the adapter now logs the unspecified-error condition (including the originating Vungle error code) via `VungleMediationLogger` so these otherwise-opaque failures are captured by the Liftoff SDK.