### PR TITLE
Chartboost 9.14.0.0

### DIFF
--- a/Chartboost/CHANGELOG.md
+++ b/Chartboost/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 9.14.0.0
+* Certified with Chartboost SDK 9.14.0.
+* Fixed a memory leak by tearing down interstitial and rewarded ads in `onDestroy()` instead of only clearing their cache.
+* Reported a signal collection failure when the Chartboost SDK has not started, instead of reporting an absent bidder token as a successful collection.
+* Fixed ad views not loading on Android API 21, and reported unsupported-API-level failures as a load failure rather than a display failure.
+* Fixed ad views intermittently failing to display when a load overlapped adapter teardown or a second load.
+* Removed the fixed delay before showing an ad view, so banners display as soon as they load. Chartboost SDK 9.14.0 handles a show that precedes the view being attached, which the delay previously worked around.
+* Reported expired interstitial and rewarded ads as a display failure instead of attempting to show them.
+* Expanded cache error reporting from 9 to 23 Chartboost error codes, so load failures surface as specific MAX errors rather than `UNSPECIFIED`.
+* Added the Chartboost auction ID as `chartboost_auction_id` inside `ad_values`, readable via `getAdValue()`, since `creative_id` carries an auction ID rather than a creative ID.
+
 ## 9.13.0.0
 * Certified with Chartboost SDK 9.13.0.
 

--- a/Chartboost/build.gradle.kts
+++ b/Chartboost/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.applovin.mobile.publish")
 }
 
-val libraryVersionName by extra("9.13.0.0")
+val libraryVersionName by extra("9.14.0.0")
 val minAppLovinSdkVersion by extra("13.0.0")
 
 android.defaultConfig.minSdk = 19

--- a/Chartboost/src/main/java/com/applovin/mediation/adapters/ChartboostMediationAdapter.java
+++ b/Chartboost/src/main/java/com/applovin/mediation/adapters/ChartboostMediationAdapter.java
@@ -62,11 +62,18 @@ public class ChartboostMediationAdapter
     private static final AtomicBoolean initialized        = new AtomicBoolean();
     private static final Mediation     MEDIATION_PROVIDER = new Mediation( "MAX", AppLovinSdk.VERSION, BuildConfig.VERSION_NAME );
 
-    private static InitializationStatus status;
+    private static volatile InitializationStatus status = InitializationStatus.INITIALIZING;
 
     private Interstitial interstitialAd;
     private Rewarded     rewardedAd;
     private Banner       adView;
+
+    // NOTE: Expiry is tracked on the listener rather than here. Each load builds a new ad and a new
+    // listener, but a superseded ad's listener stays registered with the Chartboost SDK and can still
+    // deliver `onAdExpired`. An adapter-level flag would let that late callback mark a newer, valid ad
+    // as expired. This mirrors how `hasGrantedReward` is already scoped in `RewardedAdListener`.
+    private InterstitialAdListener interstitialAdListener;
+    private RewardedAdListener     rewardedAdListener;
 
     // Explicit default constructor declaration
     public ChartboostMediationAdapter(final AppLovinSdk sdk) { super( sdk ); }
@@ -76,8 +83,6 @@ public class ChartboostMediationAdapter
     {
         if ( initialized.compareAndSet( false, true ) )
         {
-            status = InitializationStatus.INITIALIZING;
-
             final Bundle serverParameters = parameters.getServerParameters();
             final String appId = serverParameters.getString( "app_id" );
             log( "Initializing Chartboost SDK with app id: " + appId + "..." );
@@ -146,13 +151,13 @@ public class ChartboostMediationAdapter
 
         if ( interstitialAd != null )
         {
-            interstitialAd.clearCache();
+            interstitialAd.destroy();
             interstitialAd = null;
         }
 
         if ( rewardedAd != null )
         {
-            rewardedAd.clearCache();
+            rewardedAd.destroy();
             rewardedAd = null;
         }
 
@@ -169,6 +174,16 @@ public class ChartboostMediationAdapter
     {
         log( "Collecting signal..." );
 
+        // NOTE: `getBidderToken()` returns null until the Chartboost SDK has started, and MAX would
+        // otherwise record that as a successful collection carrying no token.
+        if ( !Chartboost.isSdkStarted() )
+        {
+            log( "Signal collection failed: Chartboost SDK is not started" );
+            callback.onSignalCollectionFailed( "Chartboost SDK is not started" );
+
+            return;
+        }
+
         String signal = Chartboost.getBidderToken();
         callback.onSignalCollected( signal );
     }
@@ -183,7 +198,8 @@ public class ChartboostMediationAdapter
 
         updateConsentStatus( parameters, getContext( activity ) );
 
-        interstitialAd = new Interstitial( location, new InterstitialAdListener( listener ), MEDIATION_PROVIDER );
+        interstitialAdListener = new InterstitialAdListener( listener );
+        interstitialAd = new Interstitial( location, interstitialAdListener, MEDIATION_PROVIDER );
 
         // NOTE: Do not use `isCached()` since it does not reliably indicate ad readiness.
         if ( Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP )
@@ -210,6 +226,16 @@ public class ChartboostMediationAdapter
         final String location = retrieveLocation( parameters );
         log( "Showing interstitial ad for location \"" + location + "\"..." );
 
+        if ( interstitialAdListener != null && interstitialAdListener.adExpired )
+        {
+            log( "Interstitial ad expired" );
+            listener.onInterstitialAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
+                                                                         MaxAdapterError.AD_EXPIRED.getCode(),
+                                                                         MaxAdapterError.AD_EXPIRED.getMessage() ) );
+
+            return;
+        }
+
         // NOTE: Do not use `isCached()` since it does not reliably indicate ad readiness.
         if ( interstitialAd != null )
         {
@@ -234,7 +260,8 @@ public class ChartboostMediationAdapter
 
         updateConsentStatus( parameters, getContext( activity ) );
 
-        rewardedAd = new Rewarded( location, new RewardedAdListener( listener ), MEDIATION_PROVIDER );
+        rewardedAdListener = new RewardedAdListener( listener );
+        rewardedAd = new Rewarded( location, rewardedAdListener, MEDIATION_PROVIDER );
 
         // NOTE: Do not use `isCached()` since it does not reliably indicate ad readiness.
         if ( Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP )
@@ -260,6 +287,16 @@ public class ChartboostMediationAdapter
     {
         final String location = retrieveLocation( parameters );
         log( "Showing rewarded ad for location \"" + location + "\"..." );
+
+        if ( rewardedAdListener != null && rewardedAdListener.adExpired )
+        {
+            log( "Rewarded ad expired" );
+            listener.onRewardedAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
+                                                                     MaxAdapterError.AD_EXPIRED.getCode(),
+                                                                     MaxAdapterError.AD_EXPIRED.getMessage() ) );
+
+            return;
+        }
 
         // NOTE: Do not use `isCached()` since it does not reliably indicate ad readiness.
         if ( rewardedAd != null )
@@ -290,7 +327,7 @@ public class ChartboostMediationAdapter
         adView = new Banner( getContext( activity ), location, toAdSize( adFormat ), new AdViewAdListener( listener, adFormat ), MEDIATION_PROVIDER );
 
         // NOTE: Do not use `isCached()` since it does not reliably indicate ad readiness.
-        if ( Build.VERSION.SDK_INT > Build.VERSION_CODES.LOLLIPOP )
+        if ( Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP )
         {
             if ( isBidding )
             {
@@ -304,7 +341,7 @@ public class ChartboostMediationAdapter
         else  // Chartboost does not support showing ad view ads for devices with Android versions lower than 21
         {
             log( "Ad load failed: Chartboost does not support showing " + adFormat.getLabel() + " ads for devices with Android versions lower than 21" );
-            listener.onAdViewAdDisplayFailed( MaxAdapterError.INVALID_CONFIGURATION );
+            listener.onAdViewAdLoadFailed( MaxAdapterError.INVALID_CONFIGURATION );
         }
     }
 
@@ -363,12 +400,16 @@ public class ChartboostMediationAdapter
         }
     }
 
+    // NOTE: `INVALID_RESPONSE`, `INVALID_ADM` and `UNSUPPORTED_CODEC` are deliberately unmapped. The Chartboost
+    // SDK routes their sources to `SERVER_ERROR` and `ASSET_DOWNLOAD_FAILURE`, so it cannot produce those codes.
     private static MaxAdapterError toMaxError(CacheError chartboostError)
     {
         MaxAdapterError adapterError = MaxAdapterError.UNSPECIFIED;
         switch ( chartboostError.getCode() )
         {
             case INTERNAL:
+            case NO_STORAGE:
+            case NO_MRAID_JS:
                 adapterError = MaxAdapterError.INTERNAL_ERROR;
                 break;
             case INTERNET_UNAVAILABLE:
@@ -382,40 +423,51 @@ public class ChartboostMediationAdapter
                 adapterError = MaxAdapterError.NOT_INITIALIZED;
                 break;
             case ASSET_DOWNLOAD_FAILURE:
+            case INVALID_REQUEST:
                 adapterError = MaxAdapterError.BAD_REQUEST;
                 break;
             case BANNER_DISABLED:
             case BANNER_VIEW_IS_DETACHED:
+            case DISABLED:
+            case INVALID_PLACEMENT:
                 adapterError = MaxAdapterError.INVALID_CONFIGURATION;
                 break;
             case SERVER_ERROR:
+            case RATE_LIMITED:
+            case INVALID_HTML:
+            case INVALID_ASSET_URL:
+            case VAST_ERROR:
                 adapterError = MaxAdapterError.SERVER_ERROR;
+                break;
+            case TIMEOUT:
+                adapterError = MaxAdapterError.TIMEOUT;
+                break;
+            case LOAD_IN_PROGRESS:
+            case ALREADY_LOADED:
+                adapterError = MaxAdapterError.INVALID_LOAD_STATE;
+                break;
+            case WEBVIEW_FAILED:
+            case WEBVIEW_CRASHED:
+                adapterError = MaxAdapterError.WEBVIEW_ERROR;
+                break;
         }
 
         return new MaxAdapterError( adapterError, chartboostError.getCode().getErrorCode(), chartboostError.toString() );
     }
 
-    private void showAdViewDelayed(final MaxAdViewAdapterListener listener)
+    // NOTE: `creative_id` carries Chartboost's auction ID, not a creative ID, and the Chartboost SDK exposes no
+    // creative ID that could correct it. It is left in place because existing reporting already joins on it, and
+    // the same value is repeated under a truthful name so publishers have one key that means what it says.
+    private static Bundle createExtraInfo(final String auctionId)
     {
-        // Chartboost requires manual show after caching ad views. Delay to allow enough time for attaching to parent.
-        AppLovinSdkUtils.runOnUiThreadDelayed( new Runnable()
-        {
-            @Override
-            public void run()
-            {
-                if ( adView != null )
-                {
-                    adView.show();
-                }
-                else
-                {
-                    log( "Ad load failed: Chartboost Banner AdView is not ready." );
-                    listener.onAdViewAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
-                                                                           MaxAdapterError.AD_NOT_READY.getCode(),
-                                                                           MaxAdapterError.AD_NOT_READY.getMessage() ) );
-                }
-            }
-        }, 500 );
+        Bundle adValues = new Bundle( 1 );
+        adValues.putString( "chartboost_auction_id", auctionId );
+
+        Bundle extraInfo = new Bundle( 2 );
+        extraInfo.putString( "creative_id", auctionId );
+        extraInfo.putBundle( "ad_values", adValues );
+
+        return extraInfo;
     }
 
     private Context getContext(@Nullable final Activity activity)
@@ -429,7 +481,8 @@ public class ChartboostMediationAdapter
     private class InterstitialAdListener
             implements InterstitialCallback
     {
-        private final MaxInterstitialAdapterListener listener;
+        private final    MaxInterstitialAdapterListener listener;
+        private volatile boolean                        adExpired;
 
         private InterstitialAdListener(final MaxInterstitialAdapterListener listener)
         {
@@ -456,6 +509,7 @@ public class ChartboostMediationAdapter
         public void onAdExpired(@NonNull final ExpirationEvent expirationEvent)
         {
             log( "Interstitial ad expired with reason: " + expirationEvent.getReason() );
+            adExpired = true;
         }
 
         @Override
@@ -470,6 +524,9 @@ public class ChartboostMediationAdapter
             String location = showEvent.getAd().getLocation();
             if ( showError != null )
             {
+                // NOTE: There is deliberately no `ShowError` counterpart to `toMaxError( CacheError )`. Show
+                // failures report `AD_DISPLAY_FAILED` and pass the Chartboost code and message through in the
+                // mediated-network slot, which is what the other adapters in this repo do.
                 log( "Interstitial ad failed \"" + location + "\" to show with error: " + showError );
                 listener.onInterstitialAdDisplayFailed( new MaxAdapterError( MaxAdapterError.AD_DISPLAY_FAILED,
                                                                              showError.getCode().getErrorCode(),
@@ -507,10 +564,7 @@ public class ChartboostMediationAdapter
             }
             else
             {
-                Bundle extraInfo = new Bundle( 1 );
-                extraInfo.putString( "creative_id", impressionEvent.getAdID() );
-
-                listener.onInterstitialAdDisplayed( extraInfo );
+                listener.onInterstitialAdDisplayed( createExtraInfo( impressionEvent.getAdID() ) );
             }
         }
 
@@ -525,8 +579,9 @@ public class ChartboostMediationAdapter
     private class RewardedAdListener
             implements RewardedCallback
     {
-        private final MaxRewardedAdapterListener listener;
-        private       boolean                    hasGrantedReward;
+        private final    MaxRewardedAdapterListener listener;
+        private          boolean                    hasGrantedReward;
+        private volatile boolean                    adExpired;
 
         private RewardedAdListener(final MaxRewardedAdapterListener listener)
         {
@@ -553,6 +608,7 @@ public class ChartboostMediationAdapter
         public void onAdExpired(@NonNull final ExpirationEvent expirationEvent)
         {
             log( "Rewarded ad expired with reason: " + expirationEvent.getReason() );
+            adExpired = true;
         }
 
         @Override
@@ -604,10 +660,7 @@ public class ChartboostMediationAdapter
             }
             else
             {
-                Bundle extraInfo = new Bundle( 1 );
-                extraInfo.putString( "creative_id", impressionEvent.getAdID() );
-
-                listener.onRewardedAdDisplayed( extraInfo );
+                listener.onRewardedAdDisplayed( createExtraInfo( impressionEvent.getAdID() ) );
             }
         }
 
@@ -661,24 +714,32 @@ public class ChartboostMediationAdapter
 
             log( adFormat.getLabel() + " ad loaded: " + location );
 
+            final Banner loadedAdView = (Banner) cacheEvent.getAd();
+
             if ( TextUtils.isEmpty( cacheEvent.getAdID() ) )
             {
-                listener.onAdViewAdLoaded( adView );
+                listener.onAdViewAdLoaded( loadedAdView );
             }
             else
             {
-                Bundle extraInfo = new Bundle( 1 );
-                extraInfo.putString( "creative_id", cacheEvent.getAdID() );
-
-                listener.onAdViewAdLoaded( adView, extraInfo );
+                listener.onAdViewAdLoaded( loadedAdView, createExtraInfo( cacheEvent.getAdID() ) );
             }
 
-            showAdViewDelayed( listener );
+            // Chartboost requires a manual show after caching ad views. Since Chartboost SDK 9.14.0 its
+            // visibility tracker attaches to the window before it starts, and registers an
+            // OnAttachStateChangeListener when the view is not attached yet, so showing here is safe even
+            // though MAX has not added this Banner to the publisher's layout. Earlier SDK versions bound the
+            // visibility check to a view tree that was then replaced and the impression never fired, which is
+            // why the 9.13.0.0 adapter deferred this call behind a fixed 500ms delay.
+            loadedAdView.show();
         }
 
         @Override
         public void onAdExpired(@NonNull final ExpirationEvent expirationEvent)
         {
+            // NOTE: Deliberately log-only. MAX has no ad view callback for an ad that expires after it is
+            // displayed, and it drives its own banner refresh. The show in `onAdLoaded` is synchronous with
+            // the load, so there is no window between the two in which an expiry could be acted on either.
             log( "AdView ad expired with reason: " + expirationEvent.getReason() );
         }
 
@@ -731,10 +792,7 @@ public class ChartboostMediationAdapter
             }
             else
             {
-                Bundle extraInfo = new Bundle( 1 );
-                extraInfo.putString( "creative_id", impressionEvent.getAdID() );
-
-                listener.onAdViewAdDisplayed( extraInfo );
+                listener.onAdViewAdDisplayed( createExtraInfo( impressionEvent.getAdID() ) );
             }
         }
     }


### PR DESCRIPTION
# Chartboost 9.14.0.0

Certifies the adapter with Chartboost Monetization Android 9.14.0 and fixes eight
things found by auditing adapter 9.13.0.0 against the Chartboost SDK. Each fix is
justified inline in the code, next to the change it explains, so the reasoning
travels with the source. Nothing here changes the adapter's minimum AppLovin SDK
version, and nothing removes or renames anything publishers already read. Fix 8
adds one new key, which is the only publisher-visible addition.

Four of these have iOS twins we are filing separately (HB-11729 expiry reporting,
HB-11737 error mapping, HB-11738 mediation object construction, HB-11739
creative id). This PR is Android only.

## 1. Destroy interstitial and rewarded ads in `onDestroy()`

`onDestroy()` called `clearCache()` on both. In the Chartboost SDK `clearCache()`
only drops the loaded ad (`adController.clearLoadedAd()`), while `destroy()` also
cancels the ad's coroutine scope and, when the SDK is started, tears down the ad
controller. So the adapter was leaving the controller and its scope alive on
teardown.

The banner branch was already correct: `Banner` has no `destroy()`, and its
`detach()` has the same body, which the adapter already calls.

Moloco, BidMachine, PubMatic and BigoAds all call `destroy()` here.

## 2. Make the cached initialization status volatile and non-null

`private static InitializationStatus status;` was written on whichever thread
runs `initialize()` and read from `getAdapterInitializationStatus()`, with no
happens-before edge between them. It also defaulted to `null`.

This is a small window in practice, because MAX memoizes `initialize()` per
adapter class behind a lock and a promise cache, so repeat loads never re-enter
it. It is still a real data race on first use, and the null default is worse than
a defined value.

Worth knowing: 19 other adapters in this repo declare the same field
non-volatile. We are not asking you to change those, only noting that if you
consider this worth fixing, it is not a Chartboost-specific problem.

## 3. Fail signal collection when the Chartboost SDK has not started

`collectSignal` passed `Chartboost.getBidderToken()` straight to
`onSignalCollected`. That method returns `null` until the SDK has started.

**Pre-empting the obvious objection.** We know `onSignalCollected(null)` is not
silently accepted: MAX fails the collection when `TextUtils.isEmpty(signal)` and
the per-network `fail_collection_for_empty_signal` flag is on. We deliberately did
**not** change the empty-token case, because doing so would hardcode one side of a
server-side lever you control.

What changed is narrower. The adapter now checks `Chartboost.isSdkStarted()` up
front and reports that collection **cannot be attempted**, which is outside that
flag's remit. An empty token from a started SDK still flows to
`onSignalCollected` exactly as before, and the flag still governs it. This matches
`InMobiMediationAdapter.java:120-124`, which does the same precondition check
against `InMobiSdk.isSDKInitialized()`.

## 4. Fix the ad view API level guard and its failure callback

Two bugs in one guard. The check was `Build.VERSION.SDK_INT >
Build.VERSION_CODES.LOLLIPOP`, which excludes API 21 itself even though the
adapter's `minSdk` allows it. And the failure was reported through
`onAdViewAdDisplayFailed` from inside the **load** path, so MAX was told an ad
failed to display when none had loaded.

Now `>=`, and `onAdViewAdLoadFailed`.

## 5. Show the ad view the load produced, and show it immediately

`showAdViewDelayed` read the `adView` instance field 500ms after the load rather
than the `Banner` the cache callback handed it. A teardown or a second load inside
that window handed MAX a null view, or showed a different banner than the one MAX
was told about, which records no impression for the ad MAX believes is live.

Both halves are now gone. The show happens in the cache callback, using the
`Banner` that callback delivered. There is no field read, no window, and nothing
to guard.

**Why the delay existed, and why it can go.** Chartboost requires a manual `show()`
after caching an ad view, and its visibility tracker used to bind to the view tree
at the moment `show()` ran. Calling it before MAX added the `Banner` to the
publisher's layout bound the visibility check to a tree that was then replaced, so
the impression never fired. The delay was standing in for an attach signal MAX does
not give adapters.

Chartboost SDK 9.14.0 fixes that at the source, twice. The banner coordinator now
attaches the view before starting the tracker, where 9.13.0 did the reverse. And
`VisibilityTracker.start()` now registers an `OnAttachStateChangeListener` when the
view is not yet attached, refreshing its observer once it is. Showing before MAX
attaches is therefore safe on this SDK version.

This is the one change in this PR that is specific to 9.14.0. It should not be
backported to an adapter line paired with 9.13.0 or earlier, where the delay is
still doing real work. The code comment says the same.

## 6. Report expired ads to MAX instead of trying to show them

When a cached Chartboost ad expires, the SDK notifies the adapter through
`onAdExpired`. The adapter ignored it and would still attempt `show()`.

What happens then is worse than a plain failure. Expiry sets `isLoaded = false`
**and** resets the pipeline flag, so the subsequent `show()` routes down the
legacy branch, finds no app request to render, logs `Missing app request on
render`, and the coordinator returns success. MAX gets no display callback at
all, neither success nor failure, and waits out its timeout.

The adapter now tracks expiry for interstitial and rewarded, and answers a later
`show()` with `AD_DISPLAY_FAILED` wrapping `AD_EXPIRED`, matching the shape
BidMachine, BigoAds and Facebook already use.

The flag lives on the ad listener, not on the adapter. Each load builds a new ad
and a new listener, but a superseded ad keeps its listener registered with the
Chartboost SDK and can still deliver a late `onAdExpired`. An adapter-level flag
would let that mark a newer, valid ad as expired. This is how `hasGrantedReward`
is already scoped in `RewardedAdListener`. The flags are `volatile` because
`onAdExpired` always arrives on the main thread while MAX decides per operation
whether to run the show inline or post it.

Ad view expiry stays log-only, and the code says why. MAX has no ad view callback
for an ad that expires after it is displayed, and it drives its own banner
refresh. The ad view show is now synchronous with the load, so there is no
pre-show window either.

Ideally the adapter would ask the ad object instead, the way BidMachine and
BigoAds call `interstitialAd.isExpired()`. Chartboost exposes no equivalent: its
`Interstitial` offers only `cache`, `show`, `clearCache`, `destroy` and a
deprecated `isCached`. A flag is the only option available.

**Scope.** Chartboost only starts the expiration timer on its new rendering
pipeline, which the ad server selects per ad. On waterfall traffic the legacy
callback interfaces declare no expiry method, so this guard is inert. It is not a
no-op overall, since bidding traffic does take the new pipeline.

## 7. Map the cache error codes that reach MAX as UNSPECIFIED

`toMaxError(CacheError)` covered 9 of the SDK's 26 cache codes. It now covers 23.

We derived which codes to add rather than mapping the enum wholesale. The SDK has
two cache mappers, one per rendering pipeline, in `AdErrorParser.kt`, and we
counted producers for every `ChartboostError.Load.*` subtype they switch on.

Eleven of the fourteen added have live producers at 9.13.0. Three,
`LOAD_IN_PROGRESS`, `NO_MRAID_JS` and `INVALID_HTML`, do not: each appears exactly
twice in the SDK, as its definition and as its mapper arm, with nothing
constructing it. We mapped them anyway because the mapper arms already exist and
only lack a producer, which makes them the likeliest codes to go live in a later
SDK, and mapping them is inert until then.

Three other declared codes are left unmapped for the opposite reason.
`INVALID_RESPONSE`, `INVALID_ADM` and `UNSUPPORTED_CODEC` cannot be produced at
all, because the SDK routes their sources to `SERVER_ERROR` and
`ASSET_DOWNLOAD_FAILURE` instead. `default` stays `UNSPECIFIED` so codes added in
a later SDK degrade rather than mismap.

Two mappings are judgement calls and easy to overrule. `RATE_LIMITED` is an HTTP
429 from the ad server, so we bucketed it as `SERVER_ERROR` rather than
`AD_FREQUENCY_CAPPED`, which in MAX means the network declined on a frequency cap.
`NO_STORAGE` is raised on `OutOfMemoryError` and disk-write failures, so it is
`INTERNAL_ERROR` rather than a request or server problem.

### Why there is no show error mapping

The ticket behind this one also asked for a `ShowError` mapping. We are not
adding one, and the reason is convention rather than the gap being imaginary.

Every adapter in this repo with a real partner-reported show failure keeps
`AD_DISPLAY_FAILED` as the primary bucket and varies only the mediated-network
code. That holds at all 51 inline construction sites, and at every
variable-passing site we read except Verve, which shares one `toMaxError` between
its load and show paths so its non-display primaries look like a side effect
rather than a decision. Our three `onAdShown` handlers already pass the Chartboost
code and message in the mediated slot, which is more information than the 32 sites
that put a MAX constant there.

Being straight about what that leaves open: two of the codes the ticket named,
`NO_CACHED_AD` and `SESSION_NOT_STARTED`, are live and reach MAX today only as
`AD_DISPLAY_FAILED` carrying the raw Chartboost code. A show mapper would give
them a top-level triage bucket. We think matching the repo convention is worth
more than that, but it is your call and we will follow whichever you prefer.

The other two the ticket named would be dead code. `AD_EXPIRED` has no producer at
all, which is exactly why fix 6 above had to track expiry adapter-side. `NO_CONTEXT`
is constructed but the SDK discards it before it reaches a callback. Both are gaps
we have filed on our side.

## 8. Report the auction ID under an honestly named key

The adapter sends Chartboost's auction ID to MAX as `creative_id`. Every
Chartboost event's `getAdID()` returns the auction ID, which is unique per
auction, so a publisher grouping MAX reporting by `creative_id` gets one row per
auction and no creative-level rollup. Other adapters in this repo populate that
key with a real per-creative value, so Chartboost silently behaves differently in
a shared report and nothing flags it.

We cannot fix the value. The Chartboost SDK exposes no creative ID on its public
API: every public event type offers only `getAdID()` and `getAd()`, and `Ad`
itself offers only `getLocation()` and `getMediation()`. The SDK does carry a real
creative ID internally, and exposing it is a separate change on our side that we
have filed.

What the adapter can do is name the value correctly as well. The auction ID now
also travels in the nested `ad_values` Bundle as `chartboost_auction_id`,
readable through the public `MaxAd.getAdValue(String)`. This follows the pattern
`AmazonAdMarketplaceMediationAdapter.java:582-586` already ships for
`amazon_hashed_bidder_id`. That path needs MAX SDK 11.7.0+ and this adapter's
floor is 13.0.0, so there is no version gap.

`creative_id` deliberately keeps carrying the same value. Removing it would break
existing reconciliation that joins MAX `creative_id` to Chartboost `auction_id`
on bidding traffic. This adds a correct name without taking away what publishers
and tooling already depend on. Once the SDK exposes a real creative ID we would
expect to put that in `creative_id` and keep `chartboost_auction_id` where it is.

## Verification

The Chartboost module has no standalone build target in this repo, so the adapter
was compiled with `javac` 17 against the real shipped artifacts:
`applovin-sdk-13.1.0` and `chartboost-sdk-9.14.0`, plus the Android 35 platform
jar. It compiles clean under `-Xlint:all` with zero warnings, and also compiles
clean against `chartboost-sdk-9.13.0`. Nothing the adapter touches changed between
the two SDK versions: `CacheError` still has 26 codes and `ShowError` 16, both
identical sets, and the public `Interstitial`, `Rewarded`, `Banner` and
`Chartboost` APIs used here are unchanged.
